### PR TITLE
Add `bsdtar` to the containers

### DIFF
--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -15,7 +15,7 @@ ENV NODEJS_VERSION=6 \
 
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \
-    INSTALL_PKGS="rh-nodejs6 rh-nodejs6-npm rh-nodejs6-nodejs-nodemon nss_wrapper" && \
+    INSTALL_PKGS="rh-nodejs6 rh-nodejs6-npm rh-nodejs6-nodejs-nodemon nss_wrapper bsdtar" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -15,7 +15,7 @@ ENV NODEJS_VERSION=6 \
 
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \
-    INSTALL_PKGS="rh-nodejs6 rh-nodejs6-npm rh-nodejs6-nodejs-nodemon nss_wrapper" && \
+    INSTALL_PKGS="rh-nodejs6 rh-nodejs6-npm rh-nodejs6-nodejs-nodemon nss_wrapper bsdtar" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
According to infos in [1] `tar` does not like the way overlay2 plays
tricks with inodes. As a workaround it is proposed to use `bsdtar` which
handles open files and dirs differently.

[1]: https://github.com/coreos/bugs/issues/1095