### PR TITLE
Remove sed command for memory limit

### DIFF
--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -37,7 +37,6 @@ RUN . /opt/rh/rh-nodejs6/enable && npm install -g bower grunt gulp-cli phantomjs
 # writeable as OpenShift default security model is to run the container under
 # random UID.
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
-    sed -i -E -f /opt/app-root/etc/phpini.sed /etc/opt/rh/rh-php70/php.ini && \
     chmod -R ug+rwx /opt/app-root
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001

--- a/7.0/contrib/etc/phpini.sed
+++ b/7.0/contrib/etc/phpini.sed
@@ -1,1 +1,0 @@
-s/(memory_limit =) 128M/\1 ${PHP_MEMORY_LIMIT}/

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -37,7 +37,6 @@ RUN . /opt/rh/rh-nodejs6/enable && npm install -g bower grunt gulp-cli phantomjs
 # writeable as OpenShift default security model is to run the container under
 # random UID.
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
-    sed -i -E -f /opt/app-root/etc/phpini.sed /etc/opt/rh/rh-php71/php.ini && \
     chmod -R ug+rwx /opt/app-root
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001

--- a/7.1/contrib/etc/phpini.sed
+++ b/7.1/contrib/etc/phpini.sed
@@ -1,1 +1,0 @@
-s/(memory_limit =) 128M/\1 ${PHP_MEMORY_LIMIT}/


### PR DESCRIPTION
As the upstream image already reads the memory limit from an env var
[1].

[1] https://github.com/sclorg/s2i-php-container/commit/719e5200e23be18ddd5dc857db25ada11271794b